### PR TITLE
primetime_confirmation_token can now be nil

### DIFF
--- a/Lyft/Classes/LyftAvailability.swift
+++ b/Lyft/Classes/LyftAvailability.swift
@@ -118,7 +118,6 @@ public extension Lyft {
                             estimatedCostCentsMax = c["estimated_cost_cents_max"] as? Int,
                             estimatedDurationSeconds = c["estimated_duration_seconds"] as? Int,
                             estimatedDistanceMiles = c["estimated_distance_miles"] as? Float,
-                            primetimeConfirmationToken = c["primetime_confirmation_token"] as? String?,
                             primetimePercentage = c["primetime_percentage"] as? String {
                             costEstimateResponse.append(
                                 CostEstimate(
@@ -129,7 +128,7 @@ public extension Lyft {
                                     estimatedCostCentsMax: estimatedCostCentsMax,
                                     estimatedDurationSeconds: estimatedDurationSeconds,
                                     estimatedDistanceMiles: estimatedDistanceMiles,
-                                    primetimeConfirmationToken: primetimeConfirmationToken,
+                                    primetimeConfirmationToken: c["primetime_confirmation_token"] as? String,
                                     primetimePercentage: primetimePercentage
                                 )
                             )


### PR DESCRIPTION
the requestCost if let… was never completing because the Lyft Api was returning null for primetime_confirmation_token. This wasn’t an issue when using the sandbox but no CostEstimates were parsed from the live API

See [Lyft API docs](https://developer.lyft.com/docs/availability-cost) for sample response